### PR TITLE
refactor(process-marvin-result): remove `IsPassed`

### DIFF
--- a/cmd/scatr/process_marvin_result.go
+++ b/cmd/scatr/process_marvin_result.go
@@ -40,10 +40,6 @@ var processMarvinResultCmd = &cobra.Command{
 			return err
 		}
 
-		if !data.IsPassed {
-			return errors.New("The marvin run failed")
-		}
-
 		result := marvinResultToResult(data)
 		resultJSON, err := json.Marshal(result)
 		if err != nil {
@@ -86,8 +82,7 @@ type MarvinIssue struct {
 }
 
 type MarvinResult struct {
-	Issues   []MarvinIssue `json:"issues" msgpack:"issues"`
-	IsPassed bool          `json:"is_passed" msgpack:"is_passed"`
+	Issues []MarvinIssue `json:"issues" msgpack:"issues"`
 }
 
 func unmarshalMarvinResult(isMsgpack bool, file string) (*MarvinResult, error) {


### PR DESCRIPTION
The `process-marvin-result` subcommand used to fail if `is_passed` in the JSON / messagepack result was `false`. Due to how Go's zero values work, SCATR assumed it to be false if it wasn't specified, leading to an early failure exit of the test.
