### PR TITLE
Add a `version` subcommand

### DIFF
--- a/cmd/scatr/version.go
+++ b/cmd/scatr/version.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+const version = "0.2.1"
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Returns the current SCATR version",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("SCATR analyzer testing framework")
+		fmt.Println("  Version:", version)
+		fmt.Println()
+		fmt.Println("Environment:")
+		fmt.Println("  GOOS:  ", runtime.GOOS)
+		fmt.Println("  GOARCH:", runtime.GOARCH)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/cmd/scatr/version.go
+++ b/cmd/scatr/version.go
@@ -17,8 +17,8 @@ var versionCmd = &cobra.Command{
 		fmt.Println("  Version:", version)
 		fmt.Println()
 		fmt.Println("Environment:")
-		fmt.Println("  GOOS:  ", runtime.GOOS)
-		fmt.Println("  GOARCH:", runtime.GOARCH)
+		fmt.Println("  OS:  ", runtime.GOOS)
+		fmt.Println("  ARCH:", runtime.GOARCH)
 	},
 }
 


### PR DESCRIPTION
This PR adds a `version` subcommand to show the SCATR version and environment.