### PR TITLE
Fix pragmas that contain `#`

### DIFF
--- a/cmd/scatr/version.go
+++ b/cmd/scatr/version.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const version = "0.3.0"
+const version = "0.3.1"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",

--- a/pragma/pragma.go
+++ b/pragma/pragma.go
@@ -36,7 +36,7 @@ func (p *Pragma) merge(other *Pragma) {
 }
 
 var (
-	pragmaRegex = regexp.MustCompile(`\s*\[([\w-]+)](:\s*([^#]+))?`)
+	pragmaRegex = regexp.MustCompile(`\s*\[([\w-]+)](:\s*(.*))?`)
 	issueRegex  = regexp2.MustCompile(`\s*(\d+)?\s*("(.*?(?<!\\))")?`, regexp2.None)
 )
 

--- a/pragma/pragma_test.go
+++ b/pragma/pragma_test.go
@@ -155,6 +155,16 @@ func TestParsePragma(t *testing.T) {
 				Hit: map[string]bool{"GO-W1000": false, "GO-W1001": false},
 			},
 		},
+		{
+			name: "rust pragma with #[must_use]",
+			args: args{comment: "[RS-E1017]: \"Calling `.hash(_)` on expression with unit-type `#[must_use]`\""},
+			want: &Pragma{
+				Issues: map[string][]*Issue{
+					"RS-E1017": {{Message: "Calling `.hash(_)` on expression with unit-type `#[must_use]`"}},
+				},
+				Hit: map[string]bool{"RS-E1017": false},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR fixes an edge case with the pragma parser regex where it splits if it encounters a `#`.

Fixes LAE-6877