### PR TITLE
Set perm bits to 0777 (rwx) for all (ugo)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,6 +22,7 @@ archives:
       386: i386
       amd64: x86_64
     format: binary
+      mode: 0777
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,6 +22,7 @@ archives:
       386: i386
       amd64: x86_64
     format: binary
+    builds_info:
       mode: 0777
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
Explicitly set permission bits to 0777 to make SCATR binaries executable by default as until now, 0644 was used by default, i.e., executable bit was not set for all (ugo). Setting 0777 so that it is readable, modifiable, and also executable for all (user, group, others). If any user wishes to modify the permissions, they can do it independently. But by default, we should ship the binaries with 0777.

Signed-off-by: subham sarkar <80461438+subham-deepsource@users.noreply.github.com>