### PR TITLE
Fix issue collapse when previous line has code

### DIFF
--- a/pragma/file.go
+++ b/pragma/file.go
@@ -49,6 +49,7 @@ func (f *File) extractPragmas() {
 	reader := bufio.NewReader(strings.NewReader(f.Content))
 
 	currentLine := 0
+	previousLine := ""
 	var previousPragmaWithCode *Pragma
 	for {
 		currentLine++
@@ -61,6 +62,7 @@ func (f *File) extractPragmas() {
 			break
 		}
 
+		previousLine = line
 		line = strings.TrimSpace(line)
 
 		var pragma *Pragma
@@ -108,8 +110,23 @@ func (f *File) extractPragmas() {
 				continue
 			}
 
+			// Previous line also has code
+			if !hasPrefixes(previousLine, f.CommentPrefix) {
+				continue
+			}
+
 			pragma.merge(previousPragma)
 			delete(f.Pragmas, lineNum-1)
 		}
 	}
+}
+
+func hasPrefixes(line string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(line, prefix) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pragma/file.go
+++ b/pragma/file.go
@@ -48,11 +48,11 @@ func readLine(reader *bufio.Reader) (string, error) {
 func (f *File) extractPragmas() {
 	reader := bufio.NewReader(strings.NewReader(f.Content))
 
-	currentLine := 0
+	currentLineNum := 0
 	previousLine := ""
 	var previousPragmaWithCode *Pragma
 	for {
-		currentLine++
+		currentLineNum++
 
 		line, err := readLine(reader)
 		if err != nil {
@@ -66,7 +66,7 @@ func (f *File) extractPragmas() {
 		line = strings.TrimSpace(line)
 
 		var pragma *Pragma
-		lineNum := currentLine
+		lineNum := currentLineNum
 		for _, prefix := range f.CommentPrefix {
 			split := strings.Split(line, prefix)
 			if len(split) < 2 {

--- a/pragma/file_test.go
+++ b/pragma/file_test.go
@@ -352,6 +352,22 @@ issueCaseRaised(010); // [CXX-S112]`,
 				},
 			},
 		},
+		{
+			name: "issue collapse - blank line",
+			args: args{
+				content: `code();
+
+// [CXX-S112]
+issueCaseRaised(010);`,
+				commentPrefix: []string{"//"},
+			},
+			want: map[int]*Pragma{
+				4: {
+					Issues: map[string][]*Issue{"CXX-S112": {}},
+					Hit:    map[string]bool{"CXX-S112": false},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pragma/file_test.go
+++ b/pragma/file_test.go
@@ -334,6 +334,24 @@ fmt.Println("Hello") // [GO-W1003]: 30
 				},
 			},
 		},
+		{
+			name: "issue collapse bug - cxx",
+			args: args{
+				content: `issueCaseNotRaised(00); // [CXX-S111]
+issueCaseRaised(010); // [CXX-S112]`,
+				commentPrefix: []string{"//"},
+			},
+			want: map[int]*Pragma{
+				1: {
+					Issues: map[string][]*Issue{"CXX-S111": {}},
+					Hit:    map[string]bool{"CXX-S111": false},
+				},
+				2: {
+					Issues: map[string][]*Issue{"CXX-S112": {}},
+					Hit:    map[string]bool{"CXX-S112": false},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
If there is an issue marked at the end of the line as a comment it can be raised on the line or after the line even if the line itself is non-empty.

```
issueCaseNotRaised(00); // [ISSUE-CODE]
issueCaseRaised(010); // [ISSUE-CODE]
```

In the above even though the `issueCaseNotRaised` doesn’t raise the issue it will pass scatr tests as the line after raises the issue in question.

This PR fixes this bug.