### PR TITLE
Make pragmas take priority over file names

### DIFF
--- a/cmd/scatr/version.go
+++ b/cmd/scatr/version.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const version = "0.4.0"
+const version = "0.4.1"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",

--- a/runner/diff.go
+++ b/runner/diff.go
@@ -37,6 +37,12 @@ func matchFileNameIssueCodes(files map[string]*pragma.File, analysisResult *Resu
 	}
 
 	for _, file := range files {
+		// If the file already has an ignore/check pragma, do not check change its
+		// check mode.
+		if file.CheckMode != pragma.CheckAll {
+			continue
+		}
+
 		_, exists := analysisIssueCodes[file.Name]
 		if !exists {
 			continue

--- a/runner/diff.go
+++ b/runner/diff.go
@@ -37,8 +37,8 @@ func matchFileNameIssueCodes(files map[string]*pragma.File, analysisResult *Resu
 	}
 
 	for _, file := range files {
-		// If the file already has an ignore/check pragma, do not check change its
-		// check mode.
+		// If the file already has an ignore/check pragma, that takes priority.
+		// Don't check its file name in that case.
 		if file.CheckMode != pragma.CheckAll {
 			continue
 		}


### PR DESCRIPTION
Currently, SCATR overrides the check mode to check for a single issue code in case the file name is an issue code even if a `scatr-check` or a `scatr-ignore` pragma is present.

This PR changes this behavior to make the pragmas to take priority over the file name.