### PR TITLE
Fix unexpected issue being reported when pragmas are used

### DIFF
--- a/cmd/scatr/version.go
+++ b/cmd/scatr/version.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const version = "0.4.1"
+const version = "0.4.2"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",

--- a/runner/diff.go
+++ b/runner/diff.go
@@ -100,11 +100,10 @@ func diffChecksResult(
 		pragmaIssues, ok := p.Issues[iss.Code]
 		if !ok {
 			// issue code mismatch
-			// if shouldReport(f, iss.Code) {
-			// 	fmt.Println("Unexpected c:", iss.Code)
-			issues.Unexpected = append(issues.Unexpected, iss)
-			passed = false
-			// }
+			if shouldReport(f, iss.Code) {
+				issues.Unexpected = append(issues.Unexpected, iss)
+				passed = false
+			}
 			p.Hit[iss.Code] = true
 			continue
 		}


### PR DESCRIPTION
This PR fixes an edge case when an unexpected issue was being reported even when it was excluded using a file `scatr-check` or a `scatr-exclude` pragma.