### PR TITLE
Fix an issue with multi-line pragma comments

### DIFF
--- a/cmd/scatr/version.go
+++ b/cmd/scatr/version.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const version = "0.4.2"
+const version = "0.4.3"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",

--- a/pragma/file.go
+++ b/pragma/file.go
@@ -118,8 +118,8 @@ func (f *File) extractPragmas() {
 			break
 		}
 
-		previousLine = line
 		line = strings.TrimSpace(line)
+		previousLine = line
 
 		var pragma *Pragma
 		lineNum := currentLineNum

--- a/pragma/file_test.go
+++ b/pragma/file_test.go
@@ -186,6 +186,32 @@ print("Hello World")
 			},
 		},
 		{
+			name: "multi line pragma",
+			args: args{
+				content: `
+class C2 : public B {
+public:
+  // [CXX-W2008]: 34 "Grand-parent method"
+  // [CXX-W2008]: 49 "Grand-parent method"
+  int virt_1() override { return A1::virt_1() + A2::virt_1() + A3::virt_1(); }
+  // CHECK-FIXES:  int virt_1() override { return B::virt_1() + B::virt_1() + B::virt_1(); }
+};
+`,
+				commentPrefix: []string{"//"},
+			},
+			want: map[int]*Pragma{
+				6: {
+					Issues: map[string][]*Issue{
+						"CXX-W2008": {
+							{Column: 49, Message: "Grand-parent method"},
+							{Column: 34, Message: "Grand-parent method"},
+						},
+					},
+					Hit: map[string]bool{"CXX-W2008": false},
+				},
+			},
+		},
+		{
 			name: "pragmas split on multiple lines",
 			args: args{
 				content: `


### PR DESCRIPTION
This PR fixes an issue with multi-line pragmas where the pragmas were being recognized as two different pragmas when the comment was indented.